### PR TITLE
Fix-artistinfo-missing

### DIFF
--- a/music_assistant/server/providers/jellyfin/__init__.py
+++ b/music_assistant/server/providers/jellyfin/__init__.py
@@ -445,13 +445,16 @@ class JellyfinProvider(MusicProvider):
             parent_album = API.get_item(
                 self._jellyfin_server.jellyfin, current_jellyfin_track[ITEM_KEY_PARENT_ID]
             )
-            track.artists.append(
-                self._get_item_mapping(
-                    MediaType.ARTIST,
-                    parent_album[ITEM_KEY_PARENT_ID],
-                    parent_album[ITEM_KEY_ALBUM_ARTIST],
+            if ITEM_KEY_PARENT_ID in parent_album and ITEM_KEY_ALBUM_ARTIST in parent_album:
+                track.artists.append(
+                    self._get_item_mapping(
+                        MediaType.ARTIST,
+                        parent_album[ITEM_KEY_PARENT_ID],
+                        parent_album[ITEM_KEY_ALBUM_ARTIST],
+                    )
                 )
-            )
+            else:
+                track.artists.append(await self._parse_artist(name=VARIOUS_ARTISTS_NAME))
         else:
             track.artists.append(await self._parse_artist(name=VARIOUS_ARTISTS_NAME))
         if (


### PR DESCRIPTION
Scan was failing because there was no Artist info metadata. If there is no metadata provided it will use Various Artists